### PR TITLE
v0.5: tweaked parser for list-like things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mikino_api"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Adrien Champion <adrien.champion@ocamlpro.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,10 @@ categories = ["science"]
 [[example]]
 name = "sys"
 test = true
-required-features = ["parser", "demo"]
+required-features = ["parser"]
 
 [features]
 parser = []
-demo = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ you can download directly from the [Z3 release page]. You must either
 ```bash
 > cargo build --release
 > ./target/release/mikino --version
-mikino 0.1.0
+mikino 0.5.0
 ```
 
 
@@ -78,47 +78,53 @@ A (transition) system is composed of some variable declarations, of type `bool`,
 The definition of a system features an *initial predicate*. It is a boolean expression over the variables of the system that evaluate to true on the initial states of the system.
 
 > Assume now that we want to allow our counter's `cnt` variable's initial value to be anything as
-> long as it is positive. Our initial predicate will be `(≥ cnt 0)`. Note that variable `inc` is
+> long as it is positive. Our initial predicate will be `cnt ≥ 0`. Note that variable `inc` is
 > irrelevant in this predicate.
 
 Next, the *transition relation* of the system is an expression over two versions of the variables:
-the *current* variables, and the *next* variables. The transition relation is a relation between the
-current state and the next state that evaluates to true if the next state is a legal successor of
-the current one. A the *next* version of a variable `v` is simply written `v`, and its *current*
-version is written `(pre v)`.
+the *current* variables, and the *next* variables. The transition relation is a relation between
+the current state and the next state that evaluates to true if the next state is a legal successor
+of the current one. A the *next* version of a variable `v` is written `'v`, and its *current*
+version is just written `v`.
 
 > Our counter should increase by `1` whenever variable `inc` is true, and maintain its value
 > otherwise. There is several ways to write this, for instance
 >
-> ```
-> (or (and inc (= cnt (+ (pre cnt) 1))) (and (not inc) (= cnt (pre cnt))))
+> ```rust
+> (inc ⋀ 'cnt = cnt + 1) ⋁ (¬inc ⋀ 'cnt = cnt)
 > ```
 >
 > or
 >
+> ```rust
+> if inc { 'cnt = cnt + 1 } else { 'cnt = cnt }
 > ```
-> (ite     inc (= cnt (+ (pre cnt) 1))                 (= cnt (pre cnt)) )
-> ```
-
-Last, the transition system has a list of named Proof Obligations (POs) which are boolean
-expressions over the variables. The system is **safe** if and only if it is not possible to reach a
-falsification of any of those POs from the initial states by applying the transition relation
-repeatedly.
-
-> A reasonable PO for the counter system is `(≥ cnt 0)`. The system is safe for this PO as no
-> reachable state of the counter can falsify it.
 >
-> The PO `(not (= cnt 7))` does not hold in all reachable states, in fact the initial state `{ cnt:
-> 7, inc: _ }` falsifies it. But assume we change the initial predicate to be `(= cnt 0)`. Then the
-> PO is still falsifiable by applying the transition relation seven times to the (only) initial
-> state `{ cnt: 0, inc: _ }`. In all seven transitions, we need `inc` to be true so that `cnt` is
-> actually incremented.
+> or
+>
+> ```rust
+> 'cnt = if inc { cnt + 1 } else { cnt }
+> ```
 
-A falsification of a PO is a *concrete trace*: a sequence of states *i)* that starts from an initial
-state, *ii)* where successors are valid by the transition relation and *iii)* such that the last
-state of the sequence falsifies the PO.
+Last, the transition system has a list of named candidates (*candidate invariants*) which are
+boolean expressions over the variables. The system is **safe** if and only if it is not possible to
+reach a falsification of any of these candidates from the initial states by applying the transition
+relation repeatedly.
 
-> A falsification of `(not (= cnt 7))` for the last system above with the modified initial predicate
+> A reasonable candidate for the counter system is `(≥ cnt 0)`. The system is safe for this
+> candidate as no reachable state of the counter can falsify it.
+>
+> The candidate `¬(cnt = 7)` does not hold in all reachable states, in fact the initial state `{
+> cnt: 7, inc: _ }` falsifies it. But assume we change the initial predicate to be `cnt = 0`. Then
+> the candidate is still falsifiable by applying the transition relation seven times to the (only)
+> initial state `{ cnt: 0, inc: _ }`. In all seven transitions, we need `inc` to be true so that
+> `cnt` is actually incremented.
+
+A falsification of a candidate is a *concrete trace*: a sequence of states *i)* that starts from an
+initial state, *ii)* where successors are valid by the transition relation and *iii)* such that the
+last state of the sequence falsifies the PO.
+
+> A falsification of `¬(cnt = 7)` for the last system above with the modified initial predicate
 > is
 >
 > ```
@@ -152,11 +158,12 @@ state of the sequence falsifies the PO.
 
 Mikino relies on the following stellar libraries:
 
-- [`ansi_term`](https://crates.io/crates/ansi_term)
-- [`atty`](https://crates.io/crates/atty)
-- [`clap`](https://crates.io/crates/clap)
+- [`either`](https://crates.io/crates/either)
 - [`error-chain`](https://crates.io/crates/error-chain)
+- [`lazy_static`](https://crates.io/crates/lazy_static)
 - [`num`](https://crates.io/crates/num)
+- [`peg`](https://crates.io/crates/peg)
+- [`readonly`](https://crates.io/crates/readonly)
 - [`rsmt2`](https://crates.io/crates/rsmt2)
 
 

--- a/examples/sys.rs
+++ b/examples/sys.rs
@@ -10,7 +10,18 @@ fn run() {
 
     println!("parsing and building transition system...");
 
-    let _sys = mikino_api::parse::sys(input).unwrap();
+    match mikino_api::parse::sys(input) {
+        Ok(_) => (),
+        Err(e) => {
+            for e in e.into_iter() {
+                for (idx, line) in e.pretty(()).lines().enumerate() {
+                    let pref = if idx == 0 { "- " } else { "  " };
+                    println!("{}{}", line, pref);
+                }
+            }
+            std::process::exit(2);
+        }
+    }
 
     println!("success");
 }

--- a/examples/sys.rs
+++ b/examples/sys.rs
@@ -1,5 +1,3 @@
-#![feature(parser, demo)]
-
 fn run() {
     let input = mikino_api::DEMO;
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -286,7 +286,10 @@ impl<'sys> InternalChecker<'sys> {
         for (name, po) in self.sys.po_s() {
             if res.okay.contains(name) {
                 self.solver.assert_with(&po, step).chain_err(|| {
-                    format!("while asserting negation of PO `{}` at step {}", name, step)
+                    format!(
+                        "while asserting negation of candidate `{}` at step {}",
+                        name, step
+                    )
                 })?
             }
         }
@@ -299,7 +302,10 @@ impl<'sys> InternalChecker<'sys> {
         for (name, po) in self.sys.po_s() {
             let not_po = po.negated();
             self.solver.assert_with(&not_po, step).chain_err(|| {
-                format!("while asserting negation of PO `{}` at step {}", name, step)
+                format!(
+                    "while asserting negation of candidate `{}` at step {}",
+                    name, step
+                )
             })?
         }
         Ok(())
@@ -316,7 +322,7 @@ impl<'sys> InternalChecker<'sys> {
                 self.sys
                     .po_s()
                     .get_key_value(po as &str)
-                    .ok_or_else(|| format!("unknown PO `{}`", po))
+                    .ok_or_else(|| format!("unknown candidate `{}`", po))
             })
             .collect();
         for to_check in to_check {
@@ -324,7 +330,10 @@ impl<'sys> InternalChecker<'sys> {
             let not_po = po.negated();
             self.solver.push(1)?;
             self.solver.assert_with(&not_po, step).chain_err(|| {
-                format!("while asserting negation of PO `{}` at step {}", name, step)
+                format!(
+                    "while asserting negation of candidate `{}` at step {}",
+                    name, step
+                )
             })?;
             if self.solver.check_sat()? {
                 changed = true;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -301,13 +301,11 @@ impl Op {
     /// Minimal arity of `self`.
     pub fn min_arity(self) -> usize {
         match self {
-            Self::Not | Self::Add | Self::Sub => 1,
+            Self::Not | Self::Add | Self::Sub | Self::And | Self::Or => 1,
             Self::Mod
             | Self::Mul
             | Self::Div
             | Self::IDiv
-            | Self::And
-            | Self::Or
             | Self::Implies
             | Self::Eq
             | Self::Le
@@ -705,7 +703,7 @@ impl<V> PExpr<V> {
     }
 
     /// Simplifies the application of `op` to `args`, **non-recursively**.
-    fn simplify_app(op: Op, args: Vec<Self>) -> Self {
+    fn simplify_app(op: Op, mut args: Vec<Self>) -> Self {
         match (op, args.len()) {
             (Op::Sub, 1) if args[0].is_cst() => match &args[0] {
                 Self::Cst(Cst::I(i)) => Cst::I(-i).into(),
@@ -718,6 +716,9 @@ impl<V> PExpr<V> {
                 (Self::Cst(Cst::R(lft)), Self::Cst(Cst::R(rgt))) => Cst::R(lft - rgt).into(),
                 _ => panic!("trying to apply `{}` to arguments of unexpected type", op),
             },
+            (Op::Add, 1) | (Op::And, 1) | (Op::Or, 1) => {
+                args.pop().expect("[unreachable] pop on vec of len `1`")
+            }
             _ => Self::App { op, args },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ pub mod err {
         Parse {
             /// Message.
             msg: String,
-            /// Row where the error occurred.
+            /// Row where the error occurred (starts at `0`).
             row: usize,
-            /// Column where the error occured.
+            /// Column where the error occured (starts at `0`).
             col: usize,
             /// Line of the error.
             line: String,
@@ -145,7 +145,14 @@ pub mod err {
                     line,
                     ..
                 } => {
-                    write!(fmt, "parse error at {}:{}: {} | {}", row, col, msg, line)
+                    write!(
+                        fmt,
+                        "parse error at {}:{}: {} | {}",
+                        row + 1,
+                        col + 1,
+                        msg,
+                        line
+                    )
                 }
             }
         }
@@ -295,7 +302,7 @@ pub mod err {
 }
 
 /// String representation of a simple demo system, requires the `demo` feature.
-#[cfg(feature = "demo")]
+#[cfg(feature = "parser")]
 pub const DEMO: &str = r#"//! A simple demo system.
 //!
 //! Systems are declared in four ordered parts:
@@ -360,7 +367,7 @@ pub const DEMO: &str = r#"//! A simple demo system.
 //! are also supported: `if c_1 { t_1 } else if c_2 { t_2 } .... else { e }`.
 
 /// Variables.
-state {
+svars {
     /// Stop button (input).
     stop
     /// Reset button (input).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,27 +370,31 @@ state {
 }
 
 /// Initial predicate.
+/// 
+/// Comma-separated list of stateless expressions, with optional trailing comma.
 init {
     // `cnt` can be anything as long as it is positive.
-    cnt ≥ 0
+    cnt ≥ 0,
     // if `reset`, then `cnt` has to be `0`.
-    ∧ (reset ⇒ cnt = 0)
+    (reset ⇒ cnt = 0),
 }
 
 /// Transition predicate.
+/// 
+/// Comma-separated list of stateful expressions, with optional trailing comma.
 /// 
 /// - `reset` has priority over `stop`;
 /// - the `ite` stands for "if-then-else" and takes a condition, a `then` expression and an `else`
 ///   expression. These last two expressions must have the same type. In the two `ite`s below, that
 ///   type is always `bool`.
 trans {
-    if 'reset {
-        'cnt = 0
+    'cnt = if 'reset {
+        0
     } else if 'stop {
-        'cnt = cnt
+        cnt
     } else {
-        'cnt = cnt + 1
-    }
+        cnt + 1
+    },
 }
 
 /// Proof obligations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,11 +362,11 @@ pub const DEMO: &str = r#"//! A simple demo system.
 /// Variables.
 state {
     /// Stop button (input).
-    stop,
+    stop
     /// Reset button (input).
-    reset: bool
+    reset: bool,
     /// Time counter (output).
-    cnt: int
+    cnt: int,
 }
 
 /// Initial predicate.
@@ -395,8 +395,8 @@ trans {
 
 /// Proof obligations.
 candidates {
-    "cnt is positive": cnt ≥ 0
-    "cnt is not -7": ¬(cnt = -7)
-    "if reset then cnt is 0": reset ⇒ cnt = 0
+    "cnt is positive": cnt ≥ 0,
+    "cnt is not -7": ¬(cnt = -7),
+    "if reset then cnt is 0": reset ⇒ cnt = 0,
 }
 "#;

--- a/src/parse/ast.rs
+++ b/src/parse/ast.rs
@@ -186,6 +186,15 @@ impl<'txt> Ast<'txt> {
         Self::Var { ident, pon }
     }
 
+    /// Span accessor.
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Var { ident, .. } => ident.span,
+            Self::Cst(c) => c.span,
+            Self::App { op, .. } => op.span,
+        }
+    }
+
     /// Binary operator application.
     pub fn binapp(op: Spn<Op>, lft: Self, rgt: Self) -> Self {
         Self::App {

--- a/src/parse/kw.rs
+++ b/src/parse/kw.rs
@@ -47,7 +47,7 @@ build_keywords! {
     /// Mikino-specific keywords.
     mkn {
         /// Variable declaration keyword.
-        state: "state",
+        svars: "svars",
         /// Initial predicate declaration keyword.
         init: "init",
         /// Transition relation declaration keyword.

--- a/src/parse/test.rs
+++ b/src/parse/test.rs
@@ -25,12 +25,12 @@ fn error_pos() {
     run(
         "// Blah.\nerr_token",
         |input| sys(input).map(|_| "sys"),
-        Ok("error at 2:1: expected \"state\""),
+        Ok("parse error at 2:1:  | err_token<EOI>, expected \"svars\", run mikino in 'demo' mode for more details about the syntax"),
     );
     run(
         "// Blah.",
         |input| sys(input).map(|_| "sys"),
-        Ok("error at 1:9: expected \"state\""),
+        Ok("parse error at 1:9:  | // Blah.<EOI>, expected \"svars\", run mikino in 'demo' mode for more details about the syntax"),
     );
 }
 
@@ -78,12 +78,12 @@ fn span() {
     run!(12 => @(1, 4) Some("here is"), "some", Some("text"));
 
     // Last line.
-    run!(15 => @(2, 2) Some("some"), "text", None);
-    run!(16 => @(2, 3) Some("some"), "text", None);
-    run!(17 => @(2, 4) Some("some"), "text", None);
+    run!(15 => @(2, 2) Some("some"), "text<EOI>", None);
+    run!(16 => @(2, 3) Some("some"), "text<EOI>", None);
+    run!(17 => @(2, 4) Some("some"), "text<EOI>", None);
 
     // EOI.
-    run!(input.len() => @(2, 4) Some("some"), "text", None);
+    run!(input.len() => @(2, 4) Some("some"), "text<EOI>", None);
 }
 
 #[test]
@@ -138,16 +138,16 @@ parse error at 1:1
 1 | <EOI>
   | ^~~~ here\
         ",
-        r#"expected "state""#,
+        r#"expected "svars""#,
         "run mikino in 'demo' mode for more details about the syntax",
     );
 
     run!(
-        "state" =>
+        "svars" =>
         "\
 parse error at 1:6
   |
-1 | state<EOI>
+1 | svars<EOI>
   |      ^~~~ here\
         ",
         r#"expected "{""#,
@@ -155,11 +155,11 @@ parse error at 1:6
     );
 
     run!(
-        "state {}" =>
+        "svars {}" =>
         "\
 parse error at 1:8
   |
-1 | state {}<EOI>
+1 | svars {}<EOI>
   |        ^~~~ here\
         ",
         r#"expected list of "<ident>, <ident>, ... : <type>""#,
@@ -167,11 +167,11 @@ parse error at 1:8
     );
 
     run!(
-        "state { v }" =>
+        "svars { v }" =>
         "\
 parse error at 1:9
   |
-1 | state { v }<EOI>
+1 | svars { v }<EOI>
   |         ^~~~ here\
         ",
         r#"expected list of "<ident>, <ident>, ... : <type>""#,
@@ -179,11 +179,11 @@ parse error at 1:9
     );
 
     run!(
-        "state { v : int }" =>
+        "svars { v : int }" =>
         "\
 parse error at 1:18
   |
-1 | state { v : int }<EOI>
+1 | svars { v : int }<EOI>
   |                  ^~~~ here\
         ",
         r#"expected "init""#,
@@ -191,10 +191,10 @@ parse error at 1:18
     );
 
     run!(
-        "state { v : int }\ninit" =>
+        "svars { v : int }\ninit" =>
         "\
 parse error at 2:5
-  | state { v : int }
+  | svars { v : int }
 2 | init<EOI>
   |     ^~~~ here\
         ",
@@ -203,22 +203,22 @@ parse error at 2:5
     );
 
     run!(
-        "state { v : int }\ninit { " =>
+        "svars { v : int }\ninit { " =>
         "\
 parse error at 2:8
-  | state { v : int }
+  | svars { v : int }
 2 | init { <EOI>
   |        ^~~~ here\
         ",
-        r#"expected stateless expression"#,
+        r#"expected comma-separated list of stateless expressions"#,
         "run mikino in 'demo' mode for more details about the syntax",
     );
 
     run!(
-        "state { v : int }\ninit { true" =>
+        "svars { v : int }\ninit { true" =>
         "\
 parse error at 2:12
-  | state { v : int }
+  | svars { v : int }
 2 | init { true<EOI>
   |            ^~~~ here\
         ",
@@ -227,10 +227,10 @@ parse error at 2:12
     );
 
     run!(
-        "state { v : int }\ninit { true }" =>
+        "svars { v : int }\ninit { true }" =>
         "\
 parse error at 2:14
-  | state { v : int }
+  | svars { v : int }
 2 | init { true }<EOI>
   |              ^~~~ here\
         ",
@@ -239,19 +239,19 @@ parse error at 2:14
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans {" =>
+        "svars { v : int }\ninit { true }\ntrans {" =>
         "\
 parse error at 3:8
   | init { true }
 3 | trans {<EOI>
   |        ^~~~ here\
         ",
-        r#"expected stateful expression"#,
+        r#"expected comma-separated list of stateful expressions"#,
         "run mikino in 'demo' mode for more details about the syntax",
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true" =>
+        "svars { v : int }\ninit { true }\ntrans { true" =>
         "\
 parse error at 3:13
   | init { true }
@@ -263,7 +263,7 @@ parse error at 3:13
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true }" =>
+        "svars { v : int }\ninit { true }\ntrans { true }" =>
         "\
 parse error at 3:15
   | init { true }
@@ -275,7 +275,7 @@ parse error at 3:15
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true }\ncandidates" =>
+        "svars { v : int }\ninit { true }\ntrans { true }\ncandidates" =>
         "\
 parse error at 4:11
   | trans { true }
@@ -287,7 +287,7 @@ parse error at 4:11
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true }\ncandidates {" =>
+        "svars { v : int }\ninit { true }\ntrans { true }\ncandidates {" =>
         "\
 parse error at 4:13
   | trans { true }
@@ -299,7 +299,7 @@ parse error at 4:13
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true }\ncandidates { \"prop\"" =>
+        "svars { v : int }\ninit { true }\ntrans { true }\ncandidates { \"prop\"" =>
         "\
 parse error at 4:14
   | trans { true }
@@ -311,7 +311,7 @@ parse error at 4:14
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true }\ncandidates { \"prop\" :" =>
+        "svars { v : int }\ninit { true }\ntrans { true }\ncandidates { \"prop\" :" =>
         "\
 parse error at 4:14
   | trans { true }
@@ -323,7 +323,7 @@ parse error at 4:14
     );
 
     run!(
-        "state { v : int }\ninit { true }\ntrans { true }\ncandidates { \"prop\" : true" =>
+        "svars { v : int }\ninit { true }\ntrans { true }\ncandidates { \"prop\" : true" =>
         "\
 parse error at 4:27
   | trans { true }

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -51,11 +51,11 @@ impl fmt::Display for Decls {
             }
             for (idx, var) in vars.into_iter().enumerate() {
                 if idx > 0 {
-                    write!(fmt, ", ")?;
+                    write!(fmt, " ")?;
                 }
                 var.fmt(fmt)?;
             }
-            write!(fmt, ": {}", typ)?;
+            write!(fmt, ": {},", typ)?;
         }
 
         Ok(())


### PR DESCRIPTION
- readme update
- cleaned feedback (*candidate* instead of *PO*)
- [frontend](#frontend) changes

# Frontend

- `state` section now `svars` section

- all sections now take a comma-separated list of elements. Meaning depends on the section:
  - `svars`: list of state variables;
  - `init`: **conjunction** of stateless expressions;
  - `trans`: **conjunction** of stateful expressions;
  - `candidates`: list of named candidates.